### PR TITLE
Add nGQL query for recent bugs

### DIFF
--- a/ngql/recent_bugs_last_5_days.ngql
+++ b/ngql/recent_bugs_last_5_days.ngql
@@ -1,0 +1,8 @@
+# Query for bugs created within last 5 days in NebulaGraph
+# Uses the 'id' tag where property 'Modified' stores the bug timestamp string
+
+USE graphdb;
+
+MATCH (b:id)
+WHERE datetime(b.Modified) >= datetime() - duration({days: 5})
+RETURN b.name AS bug_id, b.Title AS title, b.Modified AS modified;


### PR DESCRIPTION
## Summary
- create `ngql/` directory
- add `recent_bugs_last_5_days.ngql` with query to retrieve bugs created in the last 5 days
- update query to use `MATCH` with `datetime()`/`duration()`

## Testing
- `python -m pip install -r backend/requirements-dev.txt`
- `python -m pytest -q` *(fails: TypeError: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684a7b574f8c832e8fba9f097db1d609