### PR TITLE
Add MariaDB utility

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn[standard]
 requests
 beautifulsoup4
+mariadb

--- a/tests/test_rdb.py
+++ b/tests/test_rdb.py
@@ -1,0 +1,35 @@
+from utils import rdb
+
+class DummyCursor:
+    def __init__(self):
+        self.queries = []
+        self.closed = False
+    def execute(self, query, params=None):
+        self.queries.append((query, params))
+    def close(self):
+        self.closed = True
+
+class DummyConnection:
+    def __init__(self):
+        self.cursor_obj = DummyCursor()
+        self.committed = False
+        self.closed = False
+    def cursor(self):
+        return self.cursor_obj
+    def commit(self):
+        self.committed = True
+    def close(self):
+        self.closed = True
+
+
+def test_insert_message(monkeypatch):
+    conn = DummyConnection()
+    def mock_connect(**kwargs):
+        return conn
+    monkeypatch.setattr(rdb.mariadb, 'connect', mock_connect)
+    rdb.insert_message('hello')
+    assert conn.committed is True
+    assert conn.closed is True
+    assert conn.cursor_obj.closed is True
+    assert conn.cursor_obj.queries[1] == ("INSERT INTO messages (message) VALUES (?)", ('hello',))
+

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,2 @@
+from .ptt_crawler import fetch_board_titles
+from .rdb import insert_message

--- a/utils/rdb.py
+++ b/utils/rdb.py
@@ -1,0 +1,25 @@
+import mariadb
+import os
+
+
+def insert_message(message: str) -> None:
+    """Insert a message into the `messages` table of the MariaDB database."""
+    conn = mariadb.connect(
+        host=os.getenv('DB_HOST', 'localhost'),
+        port=int(os.getenv('DB_PORT', 3306)),
+        user=os.getenv('DB_USER', 'root'),
+        password=os.getenv('DB_PASSWORD', 'example'),
+        database=os.getenv('DB_NAME', 'codex')
+    )
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS messages (id INT AUTO_INCREMENT PRIMARY KEY, message TEXT)"
+    )
+    cur.execute(
+        "INSERT INTO messages (message) VALUES (?)",
+        (message,)
+    )
+    conn.commit()
+    cur.close()
+    conn.close()
+


### PR DESCRIPTION
## Summary
- enable MariaDB usage by including the `mariadb` package
- expose `insert_message` in `utils`
- implement a simple DB writer utility
- add unit test for the DB writer

## Testing
- `pip install -r backend/requirements-dev.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a97cbd78c832e850988f95ac0fec5